### PR TITLE
Added #[derive(Clone)] to BitArray and BitVector

### DIFF
--- a/src/bit_array.rs
+++ b/src/bit_array.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 type Block = u64;
 const BLOCK_SIZE: usize = mem::size_of::<Block>() * 8;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BitArray {
     blocks: Vec<Block>,
 }

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -44,7 +44,7 @@ include!(concat!(env!("OUT_DIR"), "/const.rs"));
 /// [1] Gonzalo Navarro and Eliana Providel. 2012. Fast, small, simple rank/select on bitmaps. In Proceedings of the 11th international conference on Experimental Algorithms (SEA'12), Ralf Klasing (Ed.). Springer-Verlag, Berlin, Heidelberg, 295-306. DOI=http://dx.doi.org/10.1007/978-3-642-30850-5_26
 ///
 /// [2] rsdic by Daisuke Okanohara. [https://github.com/hillbig/rsdic](https://github.com/hillbig/rsdic)
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BitVector {
     /// Length of the vector (number of bits)
     len: u64,


### PR DESCRIPTION
To clone FIDs currently, I serialize and deserialize the struct but a simple derive in the code should work better.