### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.6] - 2020-09-28
+
+### Changed
+
+- Added #[derive(Clone)] to BitArray and BitVector [#14](https://github.com/ajalab/fid/pull/14) by [@zommiommy](https://github.com/zommiommy)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fid"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Koki Kato <koki.kato1994@gmail.com>"]
 description = "FID (Fully Indexable Dictionary) implementation for Rust"
 repository = "https://github.com/ajalab/fid"


### PR DESCRIPTION
changes:

- Added #[derive(Clone)] to BitArray and BitVector #14 by @zommiommy 