### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2020-09-30
+
+### Changed
+
+- Implemented `PartialEq` for `BitArray` and `BitVector` [#17](https://github.com/ajalab/fid/pull/17) by [@LucaCappelletti94](https://github.com/LucaCappelletti94)
+- Added `is_empty` to `FID` [#17](https://github.com/ajalab/fid/pull/17) by [@LucaCappelletti94](https://github.com/LucaCappelletti94)
+
 ## [0.1.6] - 2020-09-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fid"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Koki Kato <koki.kato1994@gmail.com>"]
 description = "FID (Fully Indexable Dictionary) implementation for Rust"
 repository = "https://github.com/ajalab/fid"


### PR DESCRIPTION
changes:

- Implemented `PartialEq` for `BitArray` and `BitVector` [#17](https://github.com/ajalab/fid/pull/17) by [@LucaCappelletti94](https://github.com/LucaCappelletti94)
- Added `is_empty` to `FID` [#17](https://github.com/ajalab/fid/pull/17) by [@LucaCappelletti94](https://github.com/LucaCappelletti94)